### PR TITLE
Update test data to have the tag exist on the site

### DIFF
--- a/test/policy_engine_data/test_contains_policy.sql
+++ b/test/policy_engine_data/test_contains_policy.sql
@@ -7,13 +7,13 @@ truncate table sites;
 truncate table clients;
 SET FOREIGN_KEY_CHECKS = 1;
 
-INSERT INTO `sites` (`id`, `name`, `created_at`, `updated_at`)
+INSERT INTO `sites` (`id`, `tag`, `name`, `created_at`, `updated_at`)
 VALUES
-  (1,'Test Contains Site 1',now(),now());
+  (1,'test_client','Test Contains Site 1',now(),now());
 
-INSERT INTO `clients` (`id`, `tag`, `shared_secret`, `ip_range`, `site_id`, `created_at`, `updated_at`)
+INSERT INTO `clients` (`id`, `shared_secret`, `ip_range`, `site_id`, `created_at`, `updated_at`)
 VALUES
-   (1,'test_client','test','10.5.0.6/32',1,now(),now());
+   (1,'test','10.5.0.6/32',1,now(),now());
 
 INSERT INTO `policies` (`id`, `name`, `description`, `created_at`, `updated_at`, `fallback`)
 VALUES

--- a/test/policy_engine_data/test_matching_policy.sql
+++ b/test/policy_engine_data/test_matching_policy.sql
@@ -7,13 +7,13 @@ truncate table sites;
 truncate table clients;
 SET FOREIGN_KEY_CHECKS = 1;
 
-INSERT INTO `sites` (`id`, `name`, `created_at`, `updated_at`)
+INSERT INTO `sites` (`id`, `tag`, `name`, `created_at`, `updated_at`)
 VALUES
-  (1,'Probation Site 1',now(),now());
+  (1,'test_client','Probation Site 1',now(),now());
 
-INSERT INTO `clients` (`id`, `tag`, `shared_secret`, `ip_range`, `site_id`, `created_at`, `updated_at`)
+INSERT INTO `clients` (`id`, `shared_secret`, `ip_range`, `site_id`, `created_at`, `updated_at`)
 VALUES
-   (1,'test_client','test','10.5.0.6/32',1,now(),now());
+   (1,'test','10.5.0.6/32',1,now(),now());
 
 INSERT INTO `policies` (`id`, `name`, `description`, `created_at`, `updated_at`, `fallback`)
 VALUES

--- a/test/policy_engine_data/test_ttls_policy_not_run.sql
+++ b/test/policy_engine_data/test_ttls_policy_not_run.sql
@@ -7,13 +7,13 @@ truncate table sites;
 truncate table clients;
 SET FOREIGN_KEY_CHECKS = 1;
 
-INSERT INTO `sites` (`id`, `name`, `created_at`, `updated_at`)
+INSERT INTO `sites` (`id`, `tag`, `name`, `created_at`, `updated_at`)
 VALUES
-  (1,'Test TTLS Site 1',now(),now());
+  (1,'test_client', 'Test TTLS Site 1',now(),now());
 
-INSERT INTO `clients` (`id`, `tag`, `shared_secret`, `ip_range`, `site_id`, `created_at`, `updated_at`)
+INSERT INTO `clients` (`id`, `shared_secret`, `ip_range`, `site_id`, `created_at`, `updated_at`)
 VALUES
-   (1,'test_client','test','10.5.0.6/32',1,now(),now());
+   (1,'test','10.5.0.6/32',1,now(),now());
 
 INSERT INTO `policies` (`id`, `name`, `description`, `created_at`, `updated_at`, `fallback`)
 VALUES


### PR DESCRIPTION
As part of a performance enhancement of the policy engine, the schema
change has moved the tag (shortname) to the site instead of the clients.

Update test data to match this.