### PR TITLE
Add verbose logging environment variable to local setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       ENABLE_CRL: "no"
       EAP_PRIVATE_KEY_PASSWORD: "whatever"
       RADSEC_PRIVATE_KEY_PASSWORD: "whatever"
+      VERBOSE_LOGGING: "true"
     command: sh -c "/scripts/bootstrap.sh"
     networks:
       vpcbr:


### PR DESCRIPTION
This will be used during automated testing to print all the logs.