### PR TITLE
Pull base images directly from Dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/network-access-control-integration-tests:ruby-3-0-2-alpine3-14
-
+FROM ruby:3.0.2-alpine3.14
 
 RUN apk --no-cache add \
       wpa_supplicant openssl \

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,8 @@ DOCKER_COMPOSE = docker-compose -f docker-compose.yml
 ADMIN=network-access-control-admin
 CLIENT=network-access-control-integration-tests
 
-authenticate-docker: check-container-registry-account-id
+authenticate-docker:
 	./authenticate_docker.sh
-
-check-container-registry-account-id:
-	./check_container_registry_account_id.sh
 
 stop:
 	${DOCKER_COMPOSE} down
@@ -66,4 +63,4 @@ test: serve
 setup-ocsp:
 	$(DOCKER_COMPOSE) exec -T ocsp /test/scripts/ocsp_responder.sh
 
-.PHONY: stop clean clone-server clone-admin build shell-client serve test generate-certs setup-ocsp authenticate-docker check-container-registry-account-id run-client
+.PHONY: stop clean clone-server clone-admin build shell-client serve test generate-certs setup-ocsp authenticate-docker run-client

--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ and then
 make clone-admin
 ```
 
-### Authenticating Docker with AWS ECR
+### Authenticating with DockerHub
 
-The Docker base image is stored in ECR. Prior to building the container you must authenticate Docker to the ECR registry. [Details can be found here](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth).
+Local development shouldn't go over the download limits of Dockerhub.
+https://docs.docker.com/docker-hub/download-rate-limit/
 
-If you have [aws-vault](https://github.com/99designs/aws-vault#installing) configured with credentials for shared services, do the following to authenticate:
+If these limits are encountered, authenticating with Docker is required:
 
-```bash
-aws-vault exec SHARED_SERVICES_VAULT_PROFILE_NAME -- aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin SHARED_SERVICES_ACCOUNT_ID.dkr.ecr.eu-west-2.amazonaws.com
 ```
+export DOCKER_USERNAME=your-docker-hub-username
+export DOCKER_PASSWORD=your-docker-hub-password
 
-Replace ```SHARED_SERVICES_VAULT_PROFILE_NAME``` and ```SHARED_SERVICES_ACCOUNT_ID``` in the command above with the profile name and ID of the shared services account configured in aws-vault.
+make authenticate-docker
+```
 
 ### Running the integration tests
 ```bash

--- a/authenticate_docker.sh
+++ b/authenticate_docker.sh
@@ -2,4 +2,4 @@
 
 set -eu pipefail
 
-aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
+docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}

--- a/check_container_registry_account_id.sh
+++ b/check_container_registry_account_id.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-if [ -z ${SHARED_SERVICES_ACCOUNT_ID} ]; then
-  echo "Please set enviroment variable SHARED_SERVICES_ACCOUNT_ID for shared services";
-  exit 1;
-fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build:
       context: .
       args:
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
         LOCAL_DEVELOPMENT: "true"
     volumes:
       - './test:/test'
@@ -30,7 +29,6 @@ services:
     build:
       context: ./test/radsecproxy
       args:
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
         LOCAL_DEVELOPMENT: "true"
     volumes:
       - './test/certs:/certs'
@@ -51,7 +49,6 @@ services:
     build:
       context: ./network-access-control-server/
       args:
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
         LOCAL_DEVELOPMENT: "true"
     expose:
       - "1812/udp"
@@ -88,15 +85,11 @@ services:
     user: root
     build:
       context: ./test/generate_certs
-      args:
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
     command: sh -c "/bootstrap.sh"
 
   ocsp:
     build:
       context: ./ocsp
-      args:
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
     volumes:
       - ./ocsp/default.conf:/etc/nginx/conf.d/default.conf:ro
       - './test:/test'
@@ -110,8 +103,6 @@ services:
   schema-test-client:
     build:
       context: ./policy_engine_schema_test_client
-      args:
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
     environment:
       DB_HOST: db
       DB_USER: root

--- a/ocsp/Dockerfile
+++ b/ocsp/Dockerfile
@@ -1,4 +1,3 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx:nginx-1-19-5-alpine
+FROM nginx:1.19.8-alpine
 
 RUN apk --no-cache add openssl

--- a/test/generate_certs/Dockerfile
+++ b/test/generate_certs/Dockerfile
@@ -1,5 +1,4 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/network-access-control-test-certs:alpine-3-13-0
+FROM alpine:3.13.0
 
 ENV TZ UTC
 ENV PYTHONUNBUFFERED=1

--- a/test/nginx/Dockerfile
+++ b/test/nginx/Dockerfile
@@ -1,2 +1,1 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx:nginx-1-19-5-alpine
+FROM nginx:1.19.8-alpine

--- a/test/radsecproxy/Dockerfile
+++ b/test/radsecproxy/Dockerfile
@@ -1,5 +1,4 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/network-access-control-test-certs:alpine-3-13-0
+FROM alpine:3.13.0
 
 ENV RADSECPROXY_VERSION 1.9.0
 


### PR DESCRIPTION
The MoJ Docker organisation has acquired licenses, which means we
don't need to manage our own base images anymore.

Developers can authenticate locally (and shouldn't get rate limited),
and CI will authenticate with service credentials.