### PR TITLE
Remove verbose logging option from integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,6 @@ services:
       ENABLE_CRL: "no"
       EAP_PRIVATE_KEY_PASSWORD: "whatever"
       RADSEC_PRIVATE_KEY_PASSWORD: "whatever"
-      VERBOSE_LOGGING: "true"
     command: sh -c "/scripts/bootstrap.sh"
     networks:
       vpcbr:


### PR DESCRIPTION
This is no longer optional and will always be kept on.