### PR TITLE
Add linux/amd64 platform to Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
         ipv4_address: 10.5.0.8
 
   server:
+    platform: "linux/amd64"
     build:
       context: ./network-access-control-server/
       args:


### PR DESCRIPTION
## Context

- this is to ensure that the correct platform is used when building Docker images (server)
  - this is to support the new Apple M1 processors